### PR TITLE
BiosCheckSum: use `register asm` extension

### DIFF
--- a/include/gba_systemcalls.h
+++ b/include/gba_systemcalls.h
@@ -99,11 +99,11 @@ static inline void Stop()	{ SystemCall(3); }
 //---------------------------------------------------------------------------------
 static inline u32 BiosCheckSum() {
 //---------------------------------------------------------------------------------
-	register u32 result;
+	register u32 result asm("r0");
 	#if	defined	( __thumb__ )
-		__asm ("SWI	0x0d\nmov %0,r0\n" :  "=r"(result) :: "r1", "r2", "r3");
+		__asm ("SWI	0x0d" :  "=r"(result) :: "r1", "r2", "r3");
 	#else
-		__asm ("SWI	0x0d<<16\nmov %0,r0\n" : "=r"(result) :: "r1", "r2", "r3");
+		__asm ("SWI	0x0d<<16" : "=r"(result) :: "r1", "r2", "r3");
 	#endif
 	return result;
 }


### PR DESCRIPTION
The `register` keyword is illegal when compiling *standard* C++17 and up
code. GCC and clang (even in parsing mode) emit a warning about that but
this can be an issue when compiling with -Werror, even when not calling
the function. The keyword was a no-op on mainstream compilers anyway.

Using the `register asm` compiler extension the `result` variable can be
forcibly bound to `r0` which is the return register of the BIOS checksum
function, thus removing the need for a subsequent `mov`, which both
compilers' optimizers weren't able to remove (even GCC, producing `adds
r0, r0, #0`).

Removing the `mov` also makes the function compile on clang, as `mov` is
not a mnemonic for `adds x, x, #0` but is expected to be the ARMv6+
Thumb-2 instruction equivalent to ARM-mode `mov`, which obviously isn't
available on the GBA.