### PR TITLE
gba_base.h: fix "section conflict" GCC error

### DIFF
--- a/include/gba_base.h
+++ b/include/gba_base.h
@@ -99,8 +99,8 @@
 #define IWRAM_CODE	__attribute__((section(".iwram"), long_call))
 #define EWRAM_CODE	__attribute__((section(".ewram"), long_call))
 
-#define IWRAM_DATA	__attribute__((section(".iwram")))
-#define EWRAM_DATA	__attribute__((section(".ewram")))
+#define IWRAM_DATA	__attribute__((section(".iwram_data")))
+#define EWRAM_DATA	__attribute__((section(".ewram_data")))
 #define EWRAM_BSS	__attribute__((section(".sbss")))
 #define ALIGN(m)	__attribute__((aligned (m)))
 


### PR DESCRIPTION
When mixing `IWRAM_CODE` and `IWRAM_DATA` in the same file, GCC generates a "section type conflict" error:

```c
#include <gba_console.h>
#include <gba_video.h>
#include <gba_interrupt.h>
#include <gba_systemcalls.h>
#include <gba_input.h>
#include <stdio.h>
#include <stdlib.h>

void IWRAM_CODE hello(void)
{
    iprintf("Hello, world!\n");
}

int IWRAM_DATA x = 1;

int main(void)
{
    irqInit();
    irqEnable(IRQ_VBLANK);

    consoleDemoInit();

    hello();
    iprintf("%i\n", x);

    while (1)
    {
        VBlankIntrWait();
    }
}
```

```
src/main.c: In function 'main':
src/main.c:14:16: error: 'x' causes a section type conflict with 'hello'
   14 | int IWRAM_DATA x = 1;
      |                ^
src/main.c:9:17: note: 'hello' was declared here
    9 | void IWRAM_CODE hello(void)
      |                 ^~~~~

```

This is quickly fixed making `IWRAM_DATA` (and `EWRAM_DATA`) map to a different section, `.iwram_data` (`.ewram_data`) instead.

The linker script handles this fine due to wildcard matching.