### PR TITLE
Replace invalid CpuFastSet() in console

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -284,7 +284,7 @@ static void newRow() {
 
 		int i;
 		for ( i = 0; i < CONSOLE_HEIGHT; i++ ) {
-			CpuFastSet( src, dst, COPY32 | (CONSOLE_WIDTH/2) );
+			CpuSet( src, dst, COPY32 | (CONSOLE_WIDTH/2) );
 			dst += (1<<5);
 			src += (1<<5);
 		}


### PR DESCRIPTION
This BIOS call can only copy in units of 8 words (32 bytes). A row is 30
entries, 2 bytes each, so the final size is 60 bytes. This isn't a valid
size for this BIOS call.

It happened to work because it copied 64 bytes instead of 60, and the
additional 4 bytes are just the unused space of the background outside of
the screen.

CpuSet() doesn't copy 8 words in a row, so it is possible to use it
instead of CpuFastSet().