### PR TITLE
Remove unnecessary comma in BG_CTRL_BITS enum

### DIFF
--- a/include/gba_video.h
+++ b/include/gba_video.h
@@ -201,7 +201,7 @@ enum BG_CTRL_BITS {
 	BG_SIZE_0		=	BG_SIZE(0),	/*!< Map Size 256x256	*/
 	BG_SIZE_1		=	BG_SIZE(1),	/*!< Map Size 512x256	*/
 	BG_SIZE_2		=	BG_SIZE(2),	/*!< Map Size 256x512	*/
-	BG_SIZE_3		=	BG_SIZE(3),	/*!< Map Size 512x512	*/
+	BG_SIZE_3		=	BG_SIZE(3)	/*!< Map Size 512x512	*/
 };
 
 #define	CHAR_BASE(m)		((m) << 2)


### PR DESCRIPTION
Certain projects, like the decompilation of the ancient homebrew _Pikachu ga Pokeboru o Aishimasu_ (ピカチュウがポケボルをアイします, Pikachu Loves Poké Balls) (https://github.com/easyaspi314/pikaaishimasu), cause warnings to be emitted when this comma is in place. Removing it fixes this warning.