### PR TITLE
Fix inconsistent function prototype in xcomms_dfopen

### DIFF
--- a/include/xcomms.h
+++ b/include/xcomms.h
@@ -43,7 +43,7 @@ void	xcomms_dprintf	(char *str, ...);
 void	xcomms_dfprintf	(int handle, char *str, ...);
 void	xcomms_dputchar	(int c);
 
-u8		xcomms_dfopen	(const char *file, const char *type);
+int		xcomms_dfopen	(const char *file, const char *type);
 void	xcomms_dfclose	(int handle);
 u8		xcomms_dfgetc	(int handle);
 void	xcomms_dfputc	(int ch, int handle);


### PR DESCRIPTION
GCC will throw away comparisons to -1, if the return value is assumed to be u8.
As XbooCommunicator will always return -1 on failed dfopen requests, it's necessary to use the proper type,
in order to avoid error handling code from being skipped during compilation.